### PR TITLE
Add mouseover/off functionality for dates

### DIFF
--- a/script.js
+++ b/script.js
@@ -19,10 +19,13 @@ nav.addEventListener('mouseout', (ev) => {
 //is the only one I can get to work on a consistent basis and I don't know why.
 const dates = document.getElementsByTagName('li');
 
-dates.addEventListener('mouseover', (ev) => {
-    ev.target.style.fontSize = "30px";
-});
-dates.addEventListener('mouseout', (ev) => {
-    ev.target.style.fontSize = '20px';
-});
+[...dates].forEach(item=>{
+    item.addEventListener
+    ('mouseover', (ev) => {
+        ev.target.style.fontSize = "30px";
+    });
+    item.addEventListener('mouseout', (ev) => {
+        ev.target.style.fontSize = '20px';
+    });
+})
 


### PR DESCRIPTION
Overall great work. The functionality I updated works now because `getElementsByTagName` returns an HTML collection that must be converted to an array and then a listener must be applied to each instance of the tag. Feel free to reach out via Slack if you have any questions.